### PR TITLE
Replace class by instance

### DIFF
--- a/relaxed_lasso/tests/test_check_estimator.py
+++ b/relaxed_lasso/tests/test_check_estimator.py
@@ -7,7 +7,7 @@ from relaxed_lasso import RelaxedLassoLarsCV
 
 
 @pytest.mark.parametrize(
-    "Estimator", [RelaxedLassoLars, RelaxedLassoLarsCV]
+    "Estimator", [RelaxedLassoLars(), RelaxedLassoLarsCV()]
 )
 def test_all_estimators(Estimator):
     return check_estimator(Estimator)


### PR DESCRIPTION
FutureWarning: Passing a class is deprecated since version 0.23 and won't be supported in 0.24. Please pass an instance instead.